### PR TITLE
fixed AddCallback error

### DIFF
--- a/src_hudhelper/hud_helper.lua
+++ b/src_hudhelper/hud_helper.lua
@@ -1254,14 +1254,17 @@ local function InitFunctions()
 		end
 	end
 
-	local function AddCallback(callback, func, arg)
-		HudHelper:AddCallback(callback, func, arg)
+	local function AddPriorityCallback(callback, priority, func, arg)
+		HudHelper:AddPriorityCallback(callback, priority, func, arg)
+
+		if not HudHelper.AddedCallbacks[callback] then
+			HudHelper.AddedCallbacks[callback] = {}
+		end
 		table.insert(HudHelper.AddedCallbacks[callback], func)
 	end
 
-	local function AddPriorityCallback(callback, priority, func, arg)
-		HudHelper:AddPriorityCallback(callback, priority, func, arg)
-		table.insert(HudHelper.AddedCallbacks[callback], func)
+	local function AddCallback(callback, func, arg)
+		AddPriorityCallback(callback, CallbackPriority.DEFAULT, func, arg)
 	end
 
 	-- Register new callbacks


### PR DESCRIPTION
Fixes an error when AddCallback is used to add a function for a callback ID that didn't have a previously created functions list for it. With this change, it might be better to remove "premade" lists altogether